### PR TITLE
Unlisted lobbies

### DIFF
--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -185,11 +185,11 @@ bool NutPunch_Join(const char* lobby_id);
 /// than immediately here.
 bool NutPunch_Host(const char* lobby_id, bool unlisted, int players);
 
-/// Make the lobby private (unlisted) after calling `NutPunch_Host`.
-void NutPunch_SetPrivateLobby(bool);
+/// Unlist the lobby after calling `NutPunch_Host`.
+void NutPunch_SetUnlisted(bool);
 
-/// Return `true` if the current lobby is private (unlisted).
-bool NutPunch_GetPrivateLobby();
+/// Return `true` if the current lobby is unlisted.
+bool NutPunch_GetUnlisted();
 
 /// Change the maximum player count after calling `NutPunch_Host`.
 void NutPunch_SetMaxPlayers(int players);
@@ -554,10 +554,10 @@ static NutPunch_LobbyInfo NP_Lobbies[NUTPUNCH_MAX_SEARCH_RESULTS] = {0};
 static NP_HeartbeatFlagsStorage NP_HeartbeatFlags = 0;
 enum {
     NP_HB_JoinExisting = 1 << 0,
-    NP_HB_PrivateLobby = 1 << 1,
+    NP_HB_Unlisted = 1 << 1,
 };
 
-static bool NP_PrivateLobby = false;
+static bool NP_Unlisted = false;
 
 static int NP_SendDirectly(NP_AddrInfo, const void*, int);
 
@@ -592,7 +592,7 @@ static void NP_CleanupPackets(NP_Data** queue) {
 }
 
 static void NP_NukeLobbyData() {
-    NP_Closing = NP_Querying = NP_PrivateLobby = false;
+    NP_Closing = NP_Querying = NP_Unlisted = false;
     NP_LocalPeer = NP_Master = NUTPUNCH_MAX_PLAYERS;
     NP_Memzero(NP_LobbyMetadata), NP_Memzero(NP_PeerMetadata);
     NP_Memzero(NP_Lobbies), NP_Memzero(NP_Peers);
@@ -907,7 +907,7 @@ static bool NutPunch_Connect(const char* lobby_id, bool sane) {
 bool NutPunch_Host(const char* lobby_id, bool unlisted, int players) {
     NP_LazyInit();
     NP_HeartbeatFlags = 0;
-    NutPunch_SetPrivateLobby(unlisted);
+    NutPunch_SetUnlisted(unlisted);
     NutPunch_SetMaxPlayers(players);
     return NutPunch_Connect(lobby_id, true);
 }
@@ -918,15 +918,15 @@ bool NutPunch_Join(const char* lobby_id) {
     return NutPunch_Connect(lobby_id, true);
 }
 
-void NutPunch_SetPrivateLobby(bool unlisted) {
+void NutPunch_SetUnlisted(bool unlisted) {
     if (unlisted)
-        NP_HeartbeatFlags |= NP_HB_PrivateLobby;
+        NP_HeartbeatFlags |= NP_HB_Unlisted;
     else
-        NP_HeartbeatFlags &= ~NP_HB_PrivateLobby;
+        NP_HeartbeatFlags &= ~NP_HB_Unlisted;
 }
 
-bool NutPunch_GetPrivateLobby() {
-    return NP_PrivateLobby;
+bool NutPunch_GetUnlisted() {
+    return NP_Unlisted;
 }
 
 void NutPunch_SetMaxPlayers(int players) {
@@ -1113,7 +1113,7 @@ static void NP_HandleBeating(NP_Message msg) {
     const bool just_joined = NP_LocalPeer == NUTPUNCH_MAX_PLAYERS;
     const NutPunch_Peer old_master = NutPunch_MasterPeer();
 
-    NP_PrivateLobby = *msg.data++;
+    NP_Unlisted = *msg.data++;
     NP_LocalPeer = *msg.data++;
     NP_Master = *msg.data++;
     NP_MaxPlayers = *msg.data++;

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -183,7 +183,13 @@ bool NutPunch_Join(const char* lobby_id);
 ///
 /// If the lobby with the same ID exists, an error status spits out of `NutPunch_Update()` rather
 /// than immediately here.
-bool NutPunch_Host(const char* lobby_id, int players);
+bool NutPunch_Host(const char* lobby_id, bool unlisted, int players);
+
+/// Make the lobby private (unlisted) after calling `NutPunch_Host`.
+void NutPunch_SetPrivateLobby(bool);
+
+/// Return `true` if the current lobby is private (unlisted).
+bool NutPunch_GetPrivateLobby();
 
 /// Change the maximum player count after calling `NutPunch_Host`.
 void NutPunch_SetMaxPlayers(int players);
@@ -271,7 +277,7 @@ void NutPunch_SendReliably(NutPunch_Channel, NutPunch_Peer, const void* data, in
 /// `NUTPUNCH_MAX_PLAYERS` and check each peer individually with `NutPunch_PeerAlive`.
 int NutPunch_PeerCount();
 
-/// Return true if you are connected to the peer with the specified index.
+/// Return `true` if you are connected to the peer with the specified index.
 ///
 /// Use `NUTPUNCH_MAX_PLAYERS` as the upper bound for iterating, and check each peer's status
 /// individually using this function.
@@ -461,6 +467,7 @@ typedef struct {
 } NP_PeerAddr;
 
 typedef struct {
+    uint8_t unlisted;
     NutPunch_Peer local, master, capacity;
     NP_PeerAddr peers[2][NUTPUNCH_MAX_PLAYERS];
     NutPunch_Metadata metadata;
@@ -547,7 +554,10 @@ static NutPunch_LobbyInfo NP_Lobbies[NUTPUNCH_MAX_SEARCH_RESULTS] = {0};
 static NP_HeartbeatFlagsStorage NP_HeartbeatFlags = 0;
 enum {
     NP_HB_JoinExisting = 1 << 0,
+    NP_HB_PrivateLobby = 1 << 1,
 };
+
+static bool NP_PrivateLobby = false;
 
 static int NP_SendDirectly(NP_AddrInfo, const void*, int);
 
@@ -582,7 +592,7 @@ static void NP_CleanupPackets(NP_Data** queue) {
 }
 
 static void NP_NukeLobbyData() {
-    NP_Closing = NP_Querying = false;
+    NP_Closing = NP_Querying = NP_PrivateLobby = false;
     NP_LocalPeer = NP_Master = NUTPUNCH_MAX_PLAYERS;
     NP_Memzero(NP_LobbyMetadata), NP_Memzero(NP_PeerMetadata);
     NP_Memzero(NP_Lobbies), NP_Memzero(NP_Peers);
@@ -894,9 +904,10 @@ static bool NutPunch_Connect(const char* lobby_id, bool sane) {
     return true;
 }
 
-bool NutPunch_Host(const char* lobby_id, int players) {
+bool NutPunch_Host(const char* lobby_id, bool unlisted, int players) {
     NP_LazyInit();
     NP_HeartbeatFlags = 0;
+    NutPunch_SetPrivateLobby(unlisted);
     NutPunch_SetMaxPlayers(players);
     return NutPunch_Connect(lobby_id, true);
 }
@@ -905,6 +916,17 @@ bool NutPunch_Join(const char* lobby_id) {
     NP_LazyInit();
     NP_HeartbeatFlags = NP_HB_JoinExisting;
     return NutPunch_Connect(lobby_id, true);
+}
+
+void NutPunch_SetPrivateLobby(bool unlisted) {
+    if (unlisted)
+        NP_HeartbeatFlags |= NP_HB_PrivateLobby;
+    else
+        NP_HeartbeatFlags &= ~NP_HB_PrivateLobby;
+}
+
+bool NutPunch_GetPrivateLobby() {
+    return NP_PrivateLobby;
 }
 
 void NutPunch_SetMaxPlayers(int players) {
@@ -1091,6 +1113,7 @@ static void NP_HandleBeating(NP_Message msg) {
     const bool just_joined = NP_LocalPeer == NUTPUNCH_MAX_PLAYERS;
     const NutPunch_Peer old_master = NutPunch_MasterPeer();
 
+    NP_PrivateLobby = *msg.data++;
     NP_LocalPeer = *msg.data++;
     NP_Master = *msg.data++;
     NP_MaxPlayers = *msg.data++;

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -49,7 +49,7 @@ extern "C" {
 /// Increment this every time you break the communications format between the peer and the
 /// NutPuncher, to make it use a different port and retain compatibility with the previous versions
 /// by keeping the old NutPunchers running.
-#define NUTPUNCH_API_VERSION (3)
+#define NUTPUNCH_API_VERSION (2)
 
 /// The UDP port used by the nutpunching mediator server.
 #define NUTPUNCH_SERVER_PORT (30000 + NUTPUNCH_API_VERSION)
@@ -178,18 +178,18 @@ void NutPunch_SetServerAddr(const char* hostname);
 /// immediately here.
 bool NutPunch_Join(const char* lobby_id);
 
-/// Host a lobby with the specified ID and maximum player count. Return `false` if a network error
+/// Host a lobby with the specified ID. Return `false` if a network error
 /// occurs and `true` otherwise.
 ///
 /// If the lobby with the same ID exists, an error status spits out of `NutPunch_Update()` rather
 /// than immediately here.
-bool NutPunch_Host(const char* lobby_id, bool unlisted, int players);
+bool NutPunch_Host(const char* lobby_id);
 
 /// Unlist the lobby after calling `NutPunch_Host`.
 void NutPunch_SetUnlisted(bool);
 
 /// Return `true` if the current lobby is unlisted.
-bool NutPunch_GetUnlisted();
+bool NutPunch_IsUnlisted();
 
 /// Change the maximum player count after calling `NutPunch_Host`.
 void NutPunch_SetMaxPlayers(int players);
@@ -904,11 +904,9 @@ static bool NutPunch_Connect(const char* lobby_id, bool sane) {
     return true;
 }
 
-bool NutPunch_Host(const char* lobby_id, bool unlisted, int players) {
+bool NutPunch_Host(const char* lobby_id) {
     NP_LazyInit();
     NP_HeartbeatFlags = 0;
-    NutPunch_SetUnlisted(unlisted);
-    NutPunch_SetMaxPlayers(players);
     return NutPunch_Connect(lobby_id, true);
 }
 
@@ -925,7 +923,7 @@ void NutPunch_SetUnlisted(bool unlisted) {
         NP_HeartbeatFlags &= ~NP_HB_Unlisted;
 }
 
-bool NutPunch_GetUnlisted() {
+bool NutPunch_IsUnlisted() {
     return NP_Unlisted;
 }
 

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -49,7 +49,7 @@ extern "C" {
 /// Increment this every time you break the communications format between the peer and the
 /// NutPuncher, to make it use a different port and retain compatibility with the previous versions
 /// by keeping the old NutPunchers running.
-#define NUTPUNCH_API_VERSION (2)
+#define NUTPUNCH_API_VERSION (3)
 
 /// The UDP port used by the nutpunching mediator server.
 #define NUTPUNCH_SERVER_PORT (30000 + NUTPUNCH_API_VERSION)

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -223,6 +223,7 @@ struct Player {
 
 struct Lobby {
     NutPunch_LobbyId id = {0};
+    bool unlisted = false;
     uint8_t capacity = NUTPUNCH_MAX_PLAYERS;
     Player players[NUTPUNCH_MAX_PLAYERS] = {};
     Metadata metadata;
@@ -298,6 +299,7 @@ struct Lobby {
         player.countdown = KEEP_ALIVE_SECONDS * BEATS_PER_SECOND;
 
         if (idx == master()) {
+            unlisted = flags & NP_HB_PrivateLobby;
             capacity = 1 + (flags >> 4);
             metadata.load(meta);
         }
@@ -316,6 +318,7 @@ struct Lobby {
         static uint8_t buf[sizeof(NP_Header) + sizeof(NP_Beating)] = "BEAT";
         uint8_t* ptr = buf + sizeof(NP_Header);
 
+        *ptr++ = unlisted;
         *ptr++ = idx;
         *ptr++ = master();
         *ptr++ = capacity;
@@ -424,7 +427,7 @@ static void send_lobbies(AddrInfo addr, const char* target_id) {
     std::memcpy(buf + sizeof(NP_Header), target_id, sizeof(NutPunch_LobbyId));
 
     for (const auto& [id, lobby] : lobbies) {
-        if (id != target_id)
+        if (id != target_id || lobby.unlisted)
             continue;
         std::memcpy(buf + sizeof(NP_Header) + sizeof(NutPunch_LobbyId), lobby.metadata.fields,
             sizeof(NutPunch_Metadata));
@@ -441,6 +444,9 @@ static void send_lobbies(AddrInfo addr) {
     size_t count = 0;
 
     for (const auto& [id, lobby] : lobbies) {
+        if (lobby.unlisted)
+            continue;
+
         *ptr++ = lobby.gamers(), *ptr++ = lobby.capacity;
         std::memset(ptr, 0, sizeof(NutPunch_LobbyId));
         std::memcpy(ptr, id.data(), std::strlen(lobby.fmt_id()));

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -299,7 +299,7 @@ struct Lobby {
         player.countdown = KEEP_ALIVE_SECONDS * BEATS_PER_SECOND;
 
         if (idx == master()) {
-            unlisted = flags & NP_HB_PrivateLobby;
+            unlisted = flags & NP_HB_Unlisted;
             capacity = 1 + (flags >> 4);
             metadata.load(meta);
         }

--- a/src/Test.c
+++ b/src/Test.c
@@ -49,7 +49,7 @@ static void maybe_join_netgame() {
     if (poor_key_pressed(POOR_J))
         NutPunch_Join(lobbyName);
     else if (poor_key_pressed(POOR_H))
-        NutPunch_Host(lobbyName, targetPlayerCount);
+        NutPunch_Host(lobbyName, false, targetPlayerCount);
     else
         return;
 

--- a/src/Test.c
+++ b/src/Test.c
@@ -46,12 +46,14 @@ static void maybe_join_netgame() {
     if (NutPunch_IsOnline())
         return;
 
-    if (poor_key_pressed(POOR_J))
+    if (poor_key_pressed(POOR_J)) {
         NutPunch_Join(lobbyName);
-    else if (poor_key_pressed(POOR_H))
-        NutPunch_Host(lobbyName, false, targetPlayerCount);
-    else
+    } else if (poor_key_pressed(POOR_H)) {
+        NutPunch_Host(lobbyName);
+        NutPunch_SetMaxPlayers(targetPlayerCount);
+    } else {
         return;
+    }
 
     NutPunch_SetLobbyData(magicKey, sizeof(magicValue), &magicValue);
 


### PR DESCRIPTION
Adds built-in unlisted lobbies. This is safer than having it be a user-made field and doesn't bloat the search results, which already has a small cap. This also makes the NutPuncher ignore `LGMA` packets for unlisted lobbies.