### PR TITLE
Overhauled lobby query

### DIFF
--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -164,7 +164,8 @@ typedef struct {
 /// A snapshot of a lobby's metadata returned by the nutpuncher.
 typedef struct {
     NutPunch_LobbyId lobby;
-    NutPunch_Metadata metadata;
+    uint8_t count;
+    const NutPunch_Field* metadata;
 } NutPunch_LobbyMetadata;
 
 /// Comparison operators used in `NutPunch_Filter`s.
@@ -550,11 +551,6 @@ typedef struct {
 } NP_Beating;
 
 typedef struct {
-    NutPunch_LobbyId id;
-    NutPunch_Metadata metadata;
-} NP_Ligma;
-
-typedef struct {
     NutPunch_Channel channel;
     NP_PacketIndex packet;
 } NP_Acky;
@@ -586,7 +582,7 @@ static void NP_HandlePing(NP_Message), NP_HandleGTFO(NP_Message), NP_HandleBeati
 static const NP_MessageType NP_MessageTypes[] = {
 	{"PING", 1 + sizeof(NutPunch_Metadata), NP_HandlePing         },
 	{"LIST", NP_ANY_LEN,                    NP_HandleListing      },
-	{"LGMA", sizeof(NP_Ligma),              NP_HandleLobbyMetadata},
+	{"LGMA", NP_ANY_LEN,                    NP_HandleLobbyMetadata},
 	{"ACKY", sizeof(NP_Acky),               NP_HandleAcky         },
 	{"DATA", NP_ANY_LEN,                    NP_HandleData         },
 	{"GTFO", 1,		                        NP_HandleGTFO         },
@@ -1259,7 +1255,8 @@ static void NP_HandleLobbyMetadata(NP_Message msg) {
 
     NutPunch_Memcpy(info.lobby, msg.data, sizeof(NutPunch_LobbyId));
     msg.data += sizeof(NutPunch_LobbyId);
-    NutPunch_Memcpy(info.metadata, msg.data, sizeof(NutPunch_Metadata));
+    info.count = (msg.size - sizeof(NutPunch_LobbyId)) / sizeof(NutPunch_Field);
+    info.metadata = (NutPunch_Field*)msg.data;
 
     NP_HandleEventCb(NPCB_LobbyMetadata, &info);
 }

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -125,6 +125,30 @@ typedef struct {
     NutPunch_Peer peer;
 } NutPunch_PeerFieldDiff;
 
+/// Special fields you can query inside `NutPunch_Filter`s.
+typedef enum {
+    /// Lobby player count.
+    NPSF_Players = 1,
+    /// Lobby max players.
+    NPSF_Capacity,
+} NutPunch_SpecialField;
+
+/// A filter for use with `NutPunch_FindLobbies`.
+typedef struct {
+    union {
+        struct {
+            uint8_t alwayszero;
+            char name[NUTPUNCH_FIELD_NAME_MAX];
+            char value[NUTPUNCH_FIELD_DATA_MAX];
+        } field;
+        struct {
+            uint8_t index;
+            int8_t value;
+        } special;
+    };
+    uint8_t comparison;
+} NutPunch_Filter;
+
 /// About as much data as you are allowed to see from lobbies you aren't part of.
 typedef struct {
     char name[sizeof(NutPunch_LobbyId) + 1];
@@ -132,6 +156,14 @@ typedef struct {
     uint8_t players, capacity;
     bool got_meta;
 } NutPunch_LobbyInfo;
+
+/// Comparison operators used in `NutPunch_Filter`s.
+typedef enum {
+    NPF_Not = 1 << 0,
+    NPF_Eq = 1 << 1,
+    NPF_Less = 1 << 2,
+    NPF_Greater = 1 << 3,
+} NutPunch_Operator;
 
 /// Describes the result of calling `NutPunch_Update`.
 typedef enum {
@@ -304,9 +336,41 @@ void NutPunch_Disconnect();
 
 /// Query the lobbies list. Use `NutPunch_GetLobby()` to retrieve the results.
 ///
+/// The list of lobbies will update after a few ticks of `NutPunch_Update`; don't expect immediate
+/// results.
+///
+/// You can optionally pass an array of filters. Each filter consists of either a special or a named
+/// metadata field, with a corresponding value to compare it to. All filters must match in order for
+/// a lobby to be listed.
+///
+/// Bitwise-or the `NPF_*` constants to set a filter's comparison flags.
+///
+/// To query "special" fields such as lobby current or max player count, pass one of the `NPSF_*`
+/// constants with an `int8_t` value to compare against. For example, to query lobbies for exactly a
+/// 2-player duo to play:
+///
+/// ```c
+/// NutPunch_Filter filters[2] = {0};
+///
+/// // exactly 2 players capacity:
+/// filters[0].special.index = NPSF_Capacity;
+/// filters[0].special.value = 2;
+/// filters[0].comparison = NPF_Eq;
+///
+/// // less than two players in the lobby so we can join:
+/// filters[1].special.index = NPSF_Players;
+/// filters[1].special.value = 2;
+/// filters[1].comparison = NPF_Less;
+///
+/// NutPunch_FindLobbies(2, &filters);
+/// ```
+///
+/// To query metadata fields, `memcpy` their names and values into the filter's `field` property.
+/// The comparison will be performed bytewise in a fashion similar to `memcmp`.
+///
 /// Request and retrieve lobby metadata by calling `NutPunch_LobbyMetadata()` with a lobby
 /// identifier.
-void NutPunch_FindLobbies();
+void NutPunch_FindLobbies(int filter_count, const NutPunch_Filter* filters);
 
 /// Extract lobby info after a call to `NutPunch_FindLobbies`. Updates every call to
 /// `NutPunch_Update`; don't expect an immediate response.
@@ -549,6 +613,7 @@ static NP_Data* NP_QueueIn[NUTPUNCH_CHANNEL_COUNT] = {0};
 static NutPunch_Metadata NP_LobbyMetadata = {0}, NP_PeerMetadata = {0};
 
 static bool NP_Querying = false;
+static NutPunch_Filter NP_Filters[NUTPUNCH_MAX_SEARCH_FILTERS] = {0};
 static NutPunch_LobbyInfo NP_Lobbies[NUTPUNCH_MAX_SEARCH_RESULTS] = {0};
 
 static NP_HeartbeatFlagsStorage NP_HeartbeatFlags = 0;
@@ -596,6 +661,7 @@ static void NP_NukeLobbyData() {
     NP_LocalPeer = NP_Master = NUTPUNCH_MAX_PLAYERS;
     NP_Memzero(NP_LobbyMetadata), NP_Memzero(NP_PeerMetadata);
     NP_Memzero(NP_Lobbies), NP_Memzero(NP_Peers);
+    NP_Memzero(NP_Filters);
 
     for (int i = 0; i < NUTPUNCH_CHANNEL_COUNT; i++) {
         NP_CleanupPackets(&NP_QueueIn[i]);
@@ -606,7 +672,7 @@ static void NP_NukeLobbyData() {
 static void NP_NukeRemote() {
     NP_LobbyId[0] = 0, NP_HeartbeatFlags = 0;
     NP_MemzeroRef(NP_PuncherAddr), NP_Memzero(NP_Peers);
-    NP_LastStatus = NPS_Idle;
+    NP_Memzero(NP_Filters), NP_LastStatus = NPS_Idle;
 }
 
 static void NP_NukeSocket(NP_Socket* sock) {
@@ -945,9 +1011,17 @@ int NutPunch_GetMaxPlayers() {
     return NP_MaxPlayers;
 }
 
-void NutPunch_FindLobbies() {
+void NutPunch_FindLobbies(int filter_count, const NutPunch_Filter* filters) {
+    if (filter_count > NUTPUNCH_MAX_SEARCH_FILTERS) {
+        NP_Warn("Filter count exceeded in `NutPunch_FindLobbies`; truncating the input");
+        filter_count = NUTPUNCH_MAX_SEARCH_FILTERS;
+    }
+
     NP_LazyInit();
     NP_Querying = NutPunch_Connect(NULL, false);
+
+    if (filter_count > 0 && filters != NULL)
+        NutPunch_Memcpy(NP_Filters, filters, filter_count * sizeof(*filters));
 }
 
 void NutPunch_Cleanup() {
@@ -1280,6 +1354,9 @@ static bool NP_SendHeartbeat() {
     if (NP_Querying) {
         NutPunch_Memcpy(ptr, "LIST", sizeof(NP_Header));
         ptr += sizeof(NP_Header);
+
+        NutPunch_Memcpy(ptr, NP_Filters, sizeof(NP_Filters));
+        ptr += sizeof(NP_Filters);
     } else {
         NutPunch_Memcpy(ptr, "JOIN", sizeof(NP_Header));
         ptr += sizeof(NP_Header);

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -243,9 +243,13 @@ NutPunch_UpdateStatus NutPunch_Update();
 /// Sends all queued outgoing packets early (before a `NutPunch_Update()`). Useful in niche cases.
 void NutPunch_Flush();
 
+/// Requests metadata from a lobby found with `NutPunch_FindLobbies()`. This works as long as the
+/// lobby stays listed.
+void NutPunch_RequestLobbyMetadata(const NutPunch_LobbyId lobby);
+
 /// Returns metadata from a lobby. Leave `lobby` as `NULL` to get metadata from the current lobby.
-/// Otherwise, if you used `NutPunch_FindLobbies()`, you can specify a lobby to get metadata from,
-/// as long as it is listed. Listed lobbies' metadata are not updated in real-time.
+/// Otherwise, if you used `NutPunch_RequestLobbyMetadata()`, you can specify a lobby to get
+/// metadata from, as long as it is listed.
 ///
 /// See `NUTPUNCH_FIELD_NAME_MAX` and `NUTPUNCH_FIELD_DATA_MAX` for the amount of data you can
 /// squeeze into a field.
@@ -751,16 +755,10 @@ static NutPunch_Field* NP_GetLobbyFields(const char* name) {
         return NP_LobbyMetadata;
 
     for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++) {
-        if (NutPunch_Memcmp(NP_Lobbies[i].name, name, sizeof(NutPunch_LobbyId)))
+        if (!NP_Lobbies[i].got_meta)
             continue;
-
-        if (NP_Lobbies[i].got_meta)
+        if (!NutPunch_Memcmp(NP_Lobbies[i].name, name, sizeof(NutPunch_LobbyId)))
             return NP_Lobbies[i].metadata;
-
-        static uint8_t buf[sizeof(NP_Header) + sizeof(NutPunch_LobbyId)] = "LIST";
-        NutPunch_Memcpy(buf + sizeof(NP_Header), name, sizeof(NutPunch_LobbyId));
-        NP_SendDirectly(NP_PuncherAddr, buf, sizeof(buf));
-        break;
     }
 
     return NULL;
@@ -839,6 +837,12 @@ static void NP_SetVar(NutPunch_Field* fields, const char* name, int size, const 
         field->size = size;
         return;
     }
+}
+
+void NutPunch_RequestLobbyData(const NutPunch_LobbyId lobby) {
+    static uint8_t buf[sizeof(NP_Header) + sizeof(NutPunch_LobbyId)] = "LIST";
+    NutPunch_Memcpy(buf + sizeof(NP_Header), lobby, sizeof(NutPunch_LobbyId));
+    NP_SendDirectly(NP_PuncherAddr, buf, sizeof(buf));
 }
 
 const void* NutPunch_GetLobbyData(const NutPunch_LobbyId lobby, const char* name, int* size) {

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -158,7 +158,7 @@ typedef struct {
 /// A list of lobbies returned by the NutPuncher.
 typedef struct {
     uint8_t count;
-    NutPunch_LobbyInfo lobbies[NUTPUNCH_MAX_SEARCH_RESULTS];
+    const NutPunch_LobbyInfo* lobbies;
 } NutPunch_LobbyList;
 
 /// A snapshot of a lobby's metadata returned by the nutpuncher.
@@ -550,11 +550,6 @@ typedef struct {
 } NP_Beating;
 
 typedef struct {
-    NutPunch_Peer players, capacity;
-    NutPunch_LobbyId id;
-} NP_Listing[NUTPUNCH_MAX_SEARCH_RESULTS];
-
-typedef struct {
     NutPunch_LobbyId id;
     NutPunch_Metadata metadata;
 } NP_Ligma;
@@ -590,11 +585,11 @@ static void NP_HandlePing(NP_Message), NP_HandleGTFO(NP_Message), NP_HandleBeati
 // clang-format off
 static const NP_MessageType NP_MessageTypes[] = {
 	{"PING", 1 + sizeof(NutPunch_Metadata), NP_HandlePing         },
-	{"LIST", sizeof(NP_Listing),            NP_HandleListing      },
+	{"LIST", NP_ANY_LEN,                    NP_HandleListing      },
 	{"LGMA", sizeof(NP_Ligma),              NP_HandleLobbyMetadata},
 	{"ACKY", sizeof(NP_Acky),               NP_HandleAcky         },
 	{"DATA", NP_ANY_LEN,                    NP_HandleData         },
-	{"GTFO", 1,		                NP_HandleGTFO         },
+	{"GTFO", 1,		                        NP_HandleGTFO         },
 	{"BEAT", sizeof(NP_Beating),            NP_HandleBeating      },
 };
 // clang-format on
@@ -1014,7 +1009,7 @@ int NutPunch_GetMaxPlayers() {
 }
 
 void NutPunch_FindLobbies(int filter_count, const NutPunch_Filter* filters) {
-    if (filter_count > NUTPUNCH_MAX_SEARCH_FILTERS) {
+    if (filters != NULL && filter_count > NUTPUNCH_MAX_SEARCH_FILTERS) {
         NP_Warn("Filter count exceeded in `NutPunch_FindLobbies`; truncating the input");
         filter_count = NUTPUNCH_MAX_SEARCH_FILTERS;
     }
@@ -1026,10 +1021,13 @@ void NutPunch_FindLobbies(int filter_count, const NutPunch_Filter* filters) {
     NutPunch_Memcpy(ptr, "LIST", sizeof(NP_Header));
     ptr += sizeof(NP_Header);
 
-    if (filter_count > 0 && filters != NULL)
+    if (filter_count > 0 && filters != NULL) {
         NutPunch_Memcpy(ptr, filters, filter_count * sizeof(NutPunch_Filter));
+        ptr += filter_count * sizeof(NutPunch_Filter);
+    }
 
-    NP_SendDirectly(NP_PuncherAddr, query, sizeof(query));
+    const int len = (int)(ptr - query);
+    NP_SendDirectly(NP_PuncherAddr, query, len);
 }
 
 void NutPunch_Cleanup() {
@@ -1246,16 +1244,8 @@ static void NP_HandleListing(NP_Message msg) {
     NP_LastBeating = NutPunch_TimeNS();
 
     NutPunch_LobbyList list = {0};
-    for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++) {
-        list.lobbies[i].players = *(uint8_t*)(msg.data++);
-        list.lobbies[i].capacity = *(uint8_t*)(msg.data++);
-
-        NutPunch_Memcpy(list.lobbies[i].name, msg.data, sizeof(NutPunch_LobbyId));
-        msg.data += sizeof(NutPunch_LobbyId);
-
-        if (NutPunch_Memcmp(list.lobbies[i].name, (NutPunch_LobbyId){0}, sizeof(NutPunch_LobbyId)))
-            ++list.count;
-    }
+    list.count = msg.size / sizeof(NutPunch_LobbyInfo);
+    list.lobbies = list.count ? (NutPunch_LobbyInfo*)msg.data : NULL;
 
     NP_HandleEventCb(NPCB_LobbyList, &list);
 }

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -151,11 +151,21 @@ typedef struct {
 
 /// About as much data as you are allowed to see from lobbies you aren't part of.
 typedef struct {
-    char name[sizeof(NutPunch_LobbyId) + 1];
-    NutPunch_Metadata metadata;
+    NutPunch_LobbyId name;
     uint8_t players, capacity;
-    bool got_meta;
 } NutPunch_LobbyInfo;
+
+/// A list of lobbies returned by the NutPuncher.
+typedef struct {
+    uint8_t count;
+    NutPunch_LobbyInfo lobbies[NUTPUNCH_MAX_SEARCH_RESULTS];
+} NutPunch_LobbyList;
+
+/// A snapshot of a lobby's metadata returned by the nutpuncher.
+typedef struct {
+    NutPunch_LobbyId lobby;
+    NutPunch_Metadata metadata;
+} NutPunch_LobbyMetadata;
 
 /// Comparison operators used in `NutPunch_Filter`s.
 typedef enum {
@@ -195,6 +205,10 @@ typedef enum {
     NPCB_LobbyMetadataChanged,
     /// Callback data: see `NutPunch_PeerFieldChanged`.
     NPCB_PeerMetadataChanged,
+    /// Callback data: see `NutPunch_LobbyList`.
+    NPCB_LobbyList,
+    /// Callback data: see `NutPunch_LobbyMetadata`.
+    NPCB_LobbyMetadata,
     /// Total callback-event count. Do not pass this to `NutPunch_Register`.
     NPCB_Count,
 } NutPunch_CallbackEvent;
@@ -203,6 +217,10 @@ typedef void (*NutPunch_Callback)(const void*);
 
 /// Set a custom NutPuncher server address.
 void NutPunch_SetServerAddr(const char* hostname);
+
+/// Connect to NutPuncher without joining a lobby, mainly for lobby queries. Return `false` if a
+/// network error occurs and `true` otherwise.
+bool NutPunch_Query();
 
 /// Join a lobby by its ID. Return `false` if a network error occurs and `true` otherwise.
 ///
@@ -243,17 +261,16 @@ NutPunch_UpdateStatus NutPunch_Update();
 /// Sends all queued outgoing packets early (before a `NutPunch_Update()`). Useful in niche cases.
 void NutPunch_Flush();
 
-/// Requests metadata from a lobby found with `NutPunch_FindLobbies()`. This works as long as the
-/// lobby stays listed.
-void NutPunch_RequestLobbyMetadata(const NutPunch_LobbyId lobby);
+/// Requests metadata from a lobby. If you aren't connected to the NutPuncher, call
+/// `NutPunch_Query()` first.
+/// Triggers a `NPCB_LobbyMetadata` callback if successful.
+void NutPunch_RequestLobbyData(const NutPunch_LobbyId lobby);
 
-/// Returns metadata from a lobby. Leave `lobby` as `NULL` to get metadata from the current lobby.
-/// Otherwise, if you used `NutPunch_RequestLobbyMetadata()`, you can specify a lobby to get
-/// metadata from, as long as it is listed.
+/// Returns metadata from a lobby.
 ///
 /// See `NUTPUNCH_FIELD_NAME_MAX` and `NUTPUNCH_FIELD_DATA_MAX` for the amount of data you can
 /// squeeze into a field.
-const void* NutPunch_GetLobbyData(const NutPunch_LobbyId lobby, const char* name, int* size);
+const void* NutPunch_GetLobbyData(const char* name, int* size);
 
 /// Returns metadata from a peer.
 ///
@@ -338,10 +355,9 @@ bool NutPunch_IsReady();
 /// Call this to gracefully disconnect from a lobby.
 void NutPunch_Disconnect();
 
-/// Query the lobbies list. Use `NutPunch_GetLobby()` to retrieve the results.
+/// Search for lobbies. If you aren't connected to the NutPuncher, call `NutPunch_Query()` first.
 ///
-/// The list of lobbies will update after a few ticks of `NutPunch_Update`; don't expect immediate
-/// results.
+/// The list of lobbies will be retrieved through the `NutPunch_LobbyList` callback.
 ///
 /// You can optionally pass an array of filters. Each filter consists of either a special or a named
 /// metadata field, with a corresponding value to compare it to. All filters must match in order for
@@ -375,14 +391,6 @@ void NutPunch_Disconnect();
 /// Request and retrieve lobby metadata by calling `NutPunch_LobbyMetadata()` with a lobby
 /// identifier.
 void NutPunch_FindLobbies(int filter_count, const NutPunch_Filter* filters);
-
-/// Extract lobby info after a call to `NutPunch_FindLobbies`. Updates every call to
-/// `NutPunch_Update`; don't expect an immediate response.
-const NutPunch_LobbyInfo* NutPunch_GetLobby(int index);
-
-/// Count how many lobbies were found after the call to `NutPunch_FindLobbies`. Updates every call
-/// to `NutPunch_Update`; don't expect an immediate response.
-int NutPunch_LobbyCount();
 
 /// Call this to reset the underlying socket in case of an inexplicable error.
 void NutPunch_Reset();
@@ -617,8 +625,6 @@ static NP_Data* NP_QueueIn[NUTPUNCH_CHANNEL_COUNT] = {0};
 static NutPunch_Metadata NP_LobbyMetadata = {0}, NP_PeerMetadata = {0};
 
 static bool NP_Querying = false;
-static NutPunch_Filter NP_Filters[NUTPUNCH_MAX_SEARCH_FILTERS] = {0};
-static NutPunch_LobbyInfo NP_Lobbies[NUTPUNCH_MAX_SEARCH_RESULTS] = {0};
 
 static NP_HeartbeatFlagsStorage NP_HeartbeatFlags = 0;
 enum {
@@ -664,8 +670,7 @@ static void NP_NukeLobbyData() {
     NP_Closing = NP_Querying = NP_Unlisted = false;
     NP_LocalPeer = NP_Master = NUTPUNCH_MAX_PLAYERS;
     NP_Memzero(NP_LobbyMetadata), NP_Memzero(NP_PeerMetadata);
-    NP_Memzero(NP_Lobbies), NP_Memzero(NP_Peers);
-    NP_Memzero(NP_Filters);
+    NP_Memzero(NP_Peers);
 
     for (int i = 0; i < NUTPUNCH_CHANNEL_COUNT; i++) {
         NP_CleanupPackets(&NP_QueueIn[i]);
@@ -676,7 +681,7 @@ static void NP_NukeLobbyData() {
 static void NP_NukeRemote() {
     NP_LobbyId[0] = 0, NP_HeartbeatFlags = 0;
     NP_MemzeroRef(NP_PuncherAddr), NP_Memzero(NP_Peers);
-    NP_Memzero(NP_Filters), NP_LastStatus = NPS_Idle;
+    NP_LastStatus = NPS_Idle;
 }
 
 static void NP_NukeSocket(NP_Socket* sock) {
@@ -748,20 +753,6 @@ static NutPunch_Field* NP_GetPeerFields(NutPunch_Peer peer) {
         return NP_Peers[peer].metadata;
     else
         return NULL;
-}
-
-static NutPunch_Field* NP_GetLobbyFields(const char* name) {
-    if (name == NULL)
-        return NP_LobbyMetadata;
-
-    for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++) {
-        if (!NP_Lobbies[i].got_meta)
-            continue;
-        if (!NutPunch_Memcmp(NP_Lobbies[i].name, name, sizeof(NutPunch_LobbyId)))
-            return NP_Lobbies[i].metadata;
-    }
-
-    return NULL;
 }
 
 static const void* NP_GetVar(const NutPunch_Field* fields, const char* name, int* size) {
@@ -845,8 +836,8 @@ void NutPunch_RequestLobbyData(const NutPunch_LobbyId lobby) {
     NP_SendDirectly(NP_PuncherAddr, buf, sizeof(buf));
 }
 
-const void* NutPunch_GetLobbyData(const NutPunch_LobbyId lobby, const char* name, int* size) {
-    return NP_GetVar(NP_GetLobbyFields(lobby), name, size);
+const void* NutPunch_GetLobbyData(const char* name, int* size) {
+    return NP_GetVar(NP_LobbyMetadata, name, size);
 }
 
 const void* NutPunch_GetPeerData(NutPunch_Peer peer, const char* name, int* size) {
@@ -948,7 +939,7 @@ sockfail:
     return false;
 }
 
-static bool NutPunch_Connect(const char* lobby_id, bool sane) {
+static bool NP_Connect(const char* lobby_id, bool sane) {
     NP_LazyInit();
     NP_NukeLobbyData();
 
@@ -976,16 +967,21 @@ static bool NutPunch_Connect(const char* lobby_id, bool sane) {
     return true;
 }
 
+bool NutPunch_Query() {
+    NP_LazyInit();
+    return NP_Querying = NP_Connect(NULL, false);
+}
+
 bool NutPunch_Host(const char* lobby_id) {
     NP_LazyInit();
     NP_HeartbeatFlags = 0;
-    return NutPunch_Connect(lobby_id, true);
+    return NP_Connect(lobby_id, true);
 }
 
 bool NutPunch_Join(const char* lobby_id) {
     NP_LazyInit();
     NP_HeartbeatFlags = NP_HB_JoinExisting;
-    return NutPunch_Connect(lobby_id, true);
+    return NP_Connect(lobby_id, true);
 }
 
 void NutPunch_SetUnlisted(bool unlisted) {
@@ -1023,11 +1019,17 @@ void NutPunch_FindLobbies(int filter_count, const NutPunch_Filter* filters) {
         filter_count = NUTPUNCH_MAX_SEARCH_FILTERS;
     }
 
-    NP_LazyInit();
-    NP_Querying = NutPunch_Connect(NULL, false);
+    static uint8_t
+        query[sizeof(NP_Header) + (NUTPUNCH_MAX_SEARCH_FILTERS * sizeof(NutPunch_Filter))] = {0};
+    uint8_t* ptr = query;
+
+    NutPunch_Memcpy(ptr, "LIST", sizeof(NP_Header));
+    ptr += sizeof(NP_Header);
 
     if (filter_count > 0 && filters != NULL)
-        NutPunch_Memcpy(NP_Filters, filters, filter_count * sizeof(*filters));
+        NutPunch_Memcpy(ptr, filters, filter_count * sizeof(NutPunch_Filter));
+
+    NP_SendDirectly(NP_PuncherAddr, query, sizeof(query));
 }
 
 void NutPunch_Cleanup() {
@@ -1243,15 +1245,19 @@ static void NP_HandleListing(NP_Message msg) {
         return;
     NP_LastBeating = NutPunch_TimeNS();
 
-    static const size_t idlen = sizeof(NutPunch_LobbyId);
-
+    NutPunch_LobbyList list = {0};
     for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++) {
-        NP_Lobbies[i].players = *(uint8_t*)(msg.data++);
-        NP_Lobbies[i].capacity = *(uint8_t*)(msg.data++);
+        list.lobbies[i].players = *(uint8_t*)(msg.data++);
+        list.lobbies[i].capacity = *(uint8_t*)(msg.data++);
 
-        NutPunch_Memcpy(NP_Lobbies[i].name, msg.data, idlen);
-        NP_Lobbies[i].name[idlen] = '\0', msg.data += idlen;
+        NutPunch_Memcpy(list.lobbies[i].name, msg.data, sizeof(NutPunch_LobbyId));
+        msg.data += sizeof(NutPunch_LobbyId);
+
+        if (NutPunch_Memcmp(list.lobbies[i].name, (NutPunch_LobbyId){0}, sizeof(NutPunch_LobbyId)))
+            ++list.count;
     }
+
+    NP_HandleEventCb(NPCB_LobbyList, &list);
 }
 
 static void NP_HandleLobbyMetadata(NP_Message msg) {
@@ -1259,14 +1265,13 @@ static void NP_HandleLobbyMetadata(NP_Message msg) {
         return;
     NP_LastBeating = NutPunch_TimeNS();
 
-    for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++) {
-        if (NutPunch_Memcmp(NP_Lobbies[i].name, msg.data, sizeof(NutPunch_LobbyId)))
-            continue;
-        msg.data += sizeof(NutPunch_LobbyId);
-        NutPunch_Memcpy(NP_Lobbies[i].metadata, msg.data, sizeof(NutPunch_Metadata));
-        NP_Lobbies[i].got_meta = true;
-        break;
-    }
+    NutPunch_LobbyMetadata info = {0};
+
+    NutPunch_Memcpy(info.lobby, msg.data, sizeof(NutPunch_LobbyId));
+    msg.data += sizeof(NutPunch_LobbyId);
+    NutPunch_Memcpy(info.metadata, msg.data, sizeof(NutPunch_Metadata));
+
+    NP_HandleEventCb(NPCB_LobbyMetadata, &info);
 }
 
 static void NP_HandleData(NP_Message msg) {
@@ -1356,14 +1361,9 @@ static bool NP_SendHeartbeat() {
     static uint8_t heartbeat[sizeof(NP_Header) + sizeof(NP_Heartbeat)] = {0};
     NP_Memzero(heartbeat);
 
-    uint8_t* ptr = heartbeat;
-    if (NP_Querying) {
-        NutPunch_Memcpy(ptr, "LIST", sizeof(NP_Header));
-        ptr += sizeof(NP_Header);
+    if (!NP_Querying) {
+        uint8_t* ptr = heartbeat;
 
-        NutPunch_Memcpy(ptr, NP_Filters, sizeof(NP_Filters));
-        ptr += sizeof(NP_Filters);
-    } else {
         NutPunch_Memcpy(ptr, "JOIN", sizeof(NP_Header));
         ptr += sizeof(NP_Header);
 
@@ -1388,21 +1388,26 @@ static bool NP_SendHeartbeat() {
 
         NutPunch_Memcpy(ptr, NP_LobbyMetadata, sizeof(NutPunch_Metadata));
         ptr += sizeof(NutPunch_Metadata);
-    }
 
-    const int len = (int)(ptr - heartbeat);
-    if (0 <= NP_SendDirectly(NP_PuncherAddr, heartbeat, len))
-        return true;
+        const int len = (int)(ptr - heartbeat);
+        if (0 <= NP_SendDirectly(NP_PuncherAddr, heartbeat, len))
+            return true;
+    }
 
     const int err = NP_SockError();
     switch (err) {
     case NP_WouldBlock:
     case NP_ConnReset:
-        return true;
+        break;
+
     default:
+        if (NP_Querying)
+            break;
         NP_Warn("Failed to send heartbeat to NutPuncher (%d)", err);
         return false;
     }
+
+    return true;
 }
 
 typedef enum {
@@ -1544,7 +1549,7 @@ static void NP_NetworkUpdate() {
                    server_timeout = NUTPUNCH_SERVER_TIMEOUT_SECS * NUTPUNCH_NS,
                    peer_timeout = NUTPUNCH_PEER_TIMEOUT_SECS * NUTPUNCH_NS;
 
-    if (now - NP_LastBeating >= server_timeout) {
+    if (!NP_Querying && now - NP_LastBeating >= server_timeout) {
         NP_Warn("NutPuncher connection timed out!");
         goto error;
     }
@@ -1693,22 +1698,6 @@ void NutPunch_Send(NutPunch_Channel channel, NutPunch_Peer peer, const void* dat
 void
 NutPunch_SendReliably(NutPunch_Channel channel, NutPunch_Peer peer, const void* data, int size) {
     NP_SendPro(peer, channel, data, size, true);
-}
-
-const NutPunch_LobbyInfo* NutPunch_GetLobby(int index) {
-    NP_LazyInit();
-    if (index >= 0 && index < NutPunch_LobbyCount())
-        return &NP_Lobbies[index];
-    return NULL;
-}
-
-int NutPunch_LobbyCount() {
-    NP_LazyInit();
-    static const NutPunch_LobbyId nully = {0};
-    for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++)
-        if (!NutPunch_Memcmp(NP_Lobbies[i].name, nully, sizeof(nully)))
-            return i;
-    return NUTPUNCH_MAX_SEARCH_RESULTS;
 }
 
 int NutPunch_PeerCount() {

--- a/include/NutPunch.h
+++ b/include/NutPunch.h
@@ -245,7 +245,7 @@ void NutPunch_Flush();
 
 /// Returns metadata from a lobby. Leave `lobby` as `NULL` to get metadata from the current lobby.
 /// Otherwise, if you used `NutPunch_FindLobbies()`, you can specify a lobby to get metadata from,
-/// as long as it is listed.
+/// as long as it is listed. Listed lobbies' metadata are not updated in real-time.
 ///
 /// See `NUTPUNCH_FIELD_NAME_MAX` and `NUTPUNCH_FIELD_DATA_MAX` for the amount of data you can
 /// squeeze into a field.
@@ -750,15 +750,17 @@ static NutPunch_Field* NP_GetLobbyFields(const char* name) {
     if (name == NULL)
         return NP_LobbyMetadata;
 
-    static uint8_t buf[sizeof(NP_Header) + sizeof(NutPunch_LobbyId)] = "LIST";
-    NutPunch_Memcpy(buf + sizeof(NP_Header), name, sizeof(NutPunch_LobbyId));
-    NP_SendDirectly(NP_PuncherAddr, buf, sizeof(buf));
-
     for (int i = 0; i < NUTPUNCH_MAX_SEARCH_RESULTS; i++) {
-        if (!NP_Lobbies[i].got_meta)
+        if (NutPunch_Memcmp(NP_Lobbies[i].name, name, sizeof(NutPunch_LobbyId)))
             continue;
-        if (!NutPunch_Memcmp(NP_Lobbies[i].name, name, sizeof(NutPunch_LobbyId)))
+
+        if (NP_Lobbies[i].got_meta)
             return NP_Lobbies[i].metadata;
+
+        static uint8_t buf[sizeof(NP_Header) + sizeof(NutPunch_LobbyId)] = "LIST";
+        NutPunch_Memcpy(buf + sizeof(NP_Header), name, sizeof(NutPunch_LobbyId));
+        NP_SendDirectly(NP_PuncherAddr, buf, sizeof(buf));
+        break;
     }
 
     return NULL;

--- a/src/Lobbyist.c
+++ b/src/Lobbyist.c
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
         NutPunch_SetServerAddr(argv[1]);
     }
 
-    NutPunch_FindLobbies();
+    NutPunch_FindLobbies(0, NULL);
 
     static const int rate = 20, ms = 1000;
     for (int t = 0; t < ms / rate; t++) {

--- a/src/Lobbyist.c
+++ b/src/Lobbyist.c
@@ -17,6 +17,27 @@ static void handle_lobby_list(const void* raw) {
         const NutPunch_LobbyInfo* lobby = &list->lobbies[i];
         printf("%i. %.*s (%u/%u)\n", i + 1, (int)sizeof(NutPunch_LobbyId), lobby->name,
             lobby->players, lobby->capacity);
+
+        NutPunch_RequestLobbyData(lobby->name);
+    }
+    printf("\n");
+}
+
+static void handle_lobby_data(const void* raw) {
+    const NutPunch_LobbyMetadata* info = raw;
+
+    printf("%.*s has ", (int)sizeof(NutPunch_LobbyId), info->lobby);
+
+    if (!info->count) {
+        printf("no data\n\n");
+        return;
+    }
+
+    printf("%u fields:\n", info->count);
+    for (int i = 0; i < info->count; i++) {
+        const NutPunch_Field* field = &info->metadata[i];
+        printf("%.*s: %.*s\n", (int)sizeof(field->name), field->name, (int)sizeof(field->data),
+            field->data);
     }
     printf("\n");
 }
@@ -30,6 +51,7 @@ int main(int argc, char* argv[]) {
     }
 
     NutPunch_Register(NPCB_LobbyList, handle_lobby_list);
+    NutPunch_Register(NPCB_LobbyMetadata, handle_lobby_data);
     NutPunch_Query();
     NutPunch_FindLobbies(0, NULL);
 

--- a/src/Lobbyist.c
+++ b/src/Lobbyist.c
@@ -4,6 +4,23 @@
 #define NUTPUNCH_IMPLEMENTATION
 #include <NutPunch.h>
 
+static void handle_lobby_list(const void* raw) {
+    const NutPunch_LobbyList* list = raw;
+
+    if (!list->count) {
+        printf("No lober\n\n");
+        return;
+    }
+
+    printf("Found %u lobbies:\n", list->count);
+    for (int i = 0; i < list->count; i++) {
+        const NutPunch_LobbyInfo* lobby = &list->lobbies[i];
+        printf("%i. %.*s (%u/%u)\n", i + 1, (int)sizeof(NutPunch_LobbyId), lobby->name,
+            lobby->players, lobby->capacity);
+    }
+    printf("\n");
+}
+
 int main(int argc, char* argv[]) {
     if (argc < 1) {
         printf("YOU FIALED ME!!!! NOW SUFFERRRRR\n");
@@ -12,50 +29,26 @@ int main(int argc, char* argv[]) {
         NutPunch_SetServerAddr(argv[1]);
     }
 
+    NutPunch_Register(NPCB_LobbyList, handle_lobby_list);
+    NutPunch_Query();
     NutPunch_FindLobbies(0, NULL);
 
-    static const int rate = 20, ms = 1000;
-    for (int t = 0; t < ms / rate; t++) {
-        // request each lobby's metadata since that's a separate step...
-        for (int i = 0; i < NutPunch_LobbyCount(); i++)
-            NutPunch_GetLobbyData(NutPunch_GetLobby(i)->name, "hello", NULL);
-
+    static int refresh = 0;
+    while (true) {
         if (NPS_Error == NutPunch_Update()) {
             printf("failed to connect or smth\n");
             return EXIT_FAILURE;
         }
 
-        NP_SleepMs(ms / rate);
-    }
-
-    int lobby_count = NutPunch_LobbyCount();
-    printf("%d %s", lobby_count, lobby_count == 1 ? "lobby" : "lobbies");
-
-    if (lobby_count)
-        printf(":\n");
-
-    static const char zeroname[NUTPUNCH_FIELD_NAME_MAX] = {0};
-
-    for (int i = 0; i < lobby_count; i++) {
-        const NutPunch_LobbyInfo* lober = NutPunch_GetLobby(i);
-
-        printf("\n'%s'", lober->name);
-
-        if (!lober->got_meta) {
-            printf("\n  no bitches :(");
-            continue;
+        if (++refresh >= 150) {
+            NutPunch_FindLobbies(0, NULL);
+            refresh = 0;
         }
 
-        const NutPunch_Field *fields = lober->metadata, *end = fields + NUTPUNCH_MAX_FIELDS,
-                             *ptr = fields;
-
-        while (ptr < end && memcmp(ptr->name, zeroname, sizeof(zeroname))) {
-            printf("\n  %.*s: %.*s", NUTPUNCH_FIELD_NAME_MAX, ptr->name, ptr->size, ptr->data);
-            ptr += 1;
-        }
-
-        printf("\n");
+        NP_SleepMs(1000 / 30);
     }
+
+    NutPunch_Disconnect();
 
     return EXIT_SUCCESS;
 }

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -491,32 +491,26 @@ static void send_lobbies(AddrInfo addr, const char* target_id) {
     }
 }
 
-static void send_lobbies(AddrInfo addr, const NutPunch_Filter* filters) {
-    static uint8_t buf[sizeof(NP_Header) + sizeof(NP_Listing)] = "LIST";
+static void send_lobbies(AddrInfo addr, size_t filter_count, const NutPunch_Filter* filters) {
+    static uint8_t buf[sizeof(NP_Header)
+                       + (NUTPUNCH_MAX_SEARCH_RESULTS * sizeof(NutPunch_LobbyInfo))] = "LIST";
     uint8_t* ptr = buf + sizeof(NP_Header);
-    size_t filter_count = 0;
 
-    for (; filter_count < NUTPUNCH_MAX_SEARCH_FILTERS; filter_count++)
-        if (is_memzero(filters[filter_count]))
-            break;
-
-    std::memset(ptr, 0, sizeof(NP_Listing));
     size_t count = 0;
 
     for (const auto& [id, lobby] : lobbies) {
         if (lobby.unlisted || !lobby.match_against(filters, filter_count))
             continue;
 
-        *ptr++ = lobby.gamers(), *ptr++ = lobby.capacity;
-        std::memset(ptr, 0, sizeof(NutPunch_LobbyId));
         std::memcpy(ptr, id.data(), std::strlen(lobby.fmt_id()));
         ptr += sizeof(NutPunch_LobbyId);
+        *ptr++ = lobby.gamers(), *ptr++ = lobby.capacity;
 
         if (++count >= NUTPUNCH_MAX_SEARCH_RESULTS)
             break;
     }
 
-    addr.send(buf, sizeof(buf));
+    addr.send(buf, ptr - buf);
 }
 
 static void kill_bro(const NutPunch_PeerId bro) {
@@ -562,8 +556,9 @@ static int receive() {
     if (!std::memcmp(heartbeat, "LIST", sizeof(NP_Header))) {
         if (rcv == sizeof(NutPunch_LobbyId)) {
             send_lobbies(pub, ptr);
-        } else if (rcv == NUTPUNCH_MAX_SEARCH_FILTERS * sizeof(NutPunch_Filter)) {
-            send_lobbies(pub, reinterpret_cast<const NutPunch_Filter*>(ptr));
+        } else if (!(rcv % sizeof(NutPunch_Filter))) {
+            send_lobbies(
+                pub, rcv / sizeof(NutPunch_Filter), reinterpret_cast<const NutPunch_Filter*>(ptr));
         } else {
             // junk...
         }

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -500,9 +500,6 @@ static void send_lobbies(AddrInfo addr, const NutPunch_Filter* filters) {
         if (is_memzero(filters[filter_count]))
             break;
 
-    if (!filter_count)
-        return;
-
     std::memset(ptr, 0, sizeof(NP_Listing));
     size_t count = 0;
 
@@ -519,8 +516,7 @@ static void send_lobbies(AddrInfo addr, const NutPunch_Filter* filters) {
             break;
     }
 
-    for (int i = 0; i < 5; i++)
-        addr.send(buf, sizeof(buf));
+    addr.send(buf, sizeof(buf));
 }
 
 static void kill_bro(const NutPunch_PeerId bro) {
@@ -566,7 +562,7 @@ static int receive() {
     if (!std::memcmp(heartbeat, "LIST", sizeof(NP_Header))) {
         if (rcv == sizeof(NutPunch_LobbyId)) {
             send_lobbies(pub, ptr);
-        } else if (rcv == sizeof(NP_Filters)) {
+        } else if (rcv == NUTPUNCH_MAX_SEARCH_FILTERS * sizeof(NutPunch_Filter)) {
             send_lobbies(pub, reinterpret_cast<const NutPunch_Filter*>(ptr));
         } else {
             // junk...

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -73,9 +73,9 @@ static bool match_field_value(const int diff, const int flags) {
     bool result = false;
 
     if (flags & NPF_Greater)
-        result |= diff > 0;
-    else if (flags & NPF_Less)
         result |= diff < 0;
+    else if (flags & NPF_Less)
+        result |= diff > 0;
 
     if (flags & NPF_Eq)
         result |= diff == 0;

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -478,15 +478,25 @@ static bool create_lobby(const char* id, const AddrInfo& pub) {
 }
 
 static void send_lobbies(AddrInfo addr, const char* target_id) {
-    static uint8_t buf[sizeof(NP_Header) + sizeof(NP_Ligma)] = "LGMA";
-    std::memcpy(buf + sizeof(NP_Header), target_id, sizeof(NutPunch_LobbyId));
+    static uint8_t buf[sizeof(NP_Header) + sizeof(NutPunch_LobbyId) + sizeof(NutPunch_Metadata)]
+        = "LGMA";
+    uint8_t* ptr = buf + sizeof(NP_Header);
+
+    std::memcpy(ptr, target_id, sizeof(NutPunch_LobbyId));
+    ptr += sizeof(NutPunch_LobbyId);
 
     for (const auto& [id, lobby] : lobbies) {
         if (id != target_id || lobby.unlisted)
             continue;
-        std::memcpy(buf + sizeof(NP_Header) + sizeof(NutPunch_LobbyId), lobby.metadata.fields,
-            sizeof(NutPunch_Metadata));
-        addr.send(buf, sizeof(buf));
+
+        for (const auto& field : lobby.metadata.fields) {
+            if (is_memzero(field))
+                continue;
+            std::memcpy(ptr, &field, sizeof(NutPunch_Field));
+            ptr += sizeof(NutPunch_Field);
+        }
+
+        addr.send(buf, ptr - buf);
         break;
     }
 }

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -70,21 +70,16 @@ static const char* fmt_lobby_id(const char* id) {
 }
 
 static bool match_field_value(const int diff, const int flags) {
-    const int eq = !diff;
-    bool result = true;
-    if (flags & NPF_Greater) {
-        result &= diff > 0;
-        if (flags & NPF_Eq)
-            result |= eq;
-    } else if (flags & NPF_Less) {
-        result &= diff < 0;
-        if (flags & NPF_Eq)
-            result |= eq;
-    } else if (flags & NPF_Eq) {
-        result &= eq;
-    } else { // junk
-        return false;
-    }
+    bool result = false;
+
+    if (flags & NPF_Greater)
+        result |= diff > 0;
+    else if (flags & NPF_Less)
+        result |= diff < 0;
+
+    if (flags & NPF_Eq)
+        result |= diff == 0;
+
     return (flags & NPF_Not) ? !result : result;
 }
 

--- a/src/NutPuncher.cpp
+++ b/src/NutPuncher.cpp
@@ -69,6 +69,25 @@ static const char* fmt_lobby_id(const char* id) {
     return buf;
 }
 
+static bool match_field_value(const int diff, const int flags) {
+    const int eq = !diff;
+    bool result = true;
+    if (flags & NPF_Greater) {
+        result &= diff > 0;
+        if (flags & NPF_Eq)
+            result |= eq;
+    } else if (flags & NPF_Less) {
+        result &= diff < 0;
+        if (flags & NPF_Eq)
+            result |= eq;
+    } else if (flags & NPF_Eq) {
+        result &= eq;
+    } else { // junk
+        return false;
+    }
+    return (flags & NPF_Not) ? !result : result;
+}
+
 struct Field : NutPunch_Field {
     Field() {
         reset();
@@ -95,6 +114,11 @@ struct Field : NutPunch_Field {
         }
 
         return our_len == arg_len && !std::memcmp(this->name, name, our_len);
+    }
+
+    bool matches(const NutPunch_Filter& filter) const {
+        const int diff = std::memcmp(data, filter.field.value, size);
+        return match_field_value(diff, filter.comparison);
     }
 
     void reset() {
@@ -247,6 +271,17 @@ struct Lobby {
         }
     }
 
+    int special(uint8_t idx) const {
+        switch (idx) {
+        case NPSF_Capacity:
+            return capacity;
+        case NPSF_Players:
+            return gamers();
+        default:
+            return 0;
+        }
+    }
+
     explicit operator bool() const {
         return gamers() > 0;
     }
@@ -352,6 +387,31 @@ struct Lobby {
         return false;
     }
 
+    bool match_against(const NutPunch_Filter* filters, size_t filter_count) const {
+        for (int f = 0; f < filter_count; f++) {
+            const auto& filter = filters[f];
+            if (filter.field.alwayszero != 0) {
+                int diff = (uint8_t)filter.special.value;
+                diff -= special(filter.special.index);
+                if (match_field_value(diff, filter.comparison))
+                    goto next_filter;
+                return false;
+            }
+            for (int m = 0; m < NUTPUNCH_MAX_FIELDS; m++) {
+                const auto& field = metadata.fields[m];
+                if (!field.named(filter.field.name))
+                    continue;
+                if (field.matches(filter))
+                    goto next_filter;
+            }
+            return false; // no field matched the filter
+        next_filter:
+            continue;
+        }
+        // All filters matched.
+        return true;
+    }
+
     NutPunch_Peer master() {
         if (master_idx < NUTPUNCH_MAX_PLAYERS && players[master_idx])
             return master_idx;
@@ -436,15 +496,23 @@ static void send_lobbies(AddrInfo addr, const char* target_id) {
     }
 }
 
-static void send_lobbies(AddrInfo addr) {
+static void send_lobbies(AddrInfo addr, const NutPunch_Filter* filters) {
     static uint8_t buf[sizeof(NP_Header) + sizeof(NP_Listing)] = "LIST";
     uint8_t* ptr = buf + sizeof(NP_Header);
+    size_t filter_count = 0;
+
+    for (; filter_count < NUTPUNCH_MAX_SEARCH_FILTERS; filter_count++)
+        if (is_memzero(filters[filter_count]))
+            break;
+
+    if (!filter_count)
+        return;
 
     std::memset(ptr, 0, sizeof(NP_Listing));
     size_t count = 0;
 
     for (const auto& [id, lobby] : lobbies) {
-        if (lobby.unlisted)
+        if (lobby.unlisted || !lobby.match_against(filters, filter_count))
             continue;
 
         *ptr++ = lobby.gamers(), *ptr++ = lobby.capacity;
@@ -503,8 +571,8 @@ static int receive() {
     if (!std::memcmp(heartbeat, "LIST", sizeof(NP_Header))) {
         if (rcv == sizeof(NutPunch_LobbyId)) {
             send_lobbies(pub, ptr);
-        } else if (rcv == 0) {
-            send_lobbies(pub);
+        } else if (rcv == sizeof(NP_Filters)) {
+            send_lobbies(pub, reinterpret_cast<const NutPunch_Filter*>(ptr));
         } else {
             // junk...
         }

--- a/src/Zalooper.c
+++ b/src/Zalooper.c
@@ -17,7 +17,8 @@ int main(int argc, char* argv[]) {
 
     if (argc > 2) {
         int players = strtol(argv[2], NULL, 10);
-        NutPunch_Host(LOBBY, players);
+        NutPunch_Host(LOBBY);
+        NutPunch_SetMaxPlayers(players);
         NP_Info("HOSTANING>..... for %d", players);
     } else {
         NutPunch_Join(LOBBY);


### PR DESCRIPTION
- Overhauled lobby searching:
  - `NutPunch_Query()` to open a socket to the NutPuncher without worrying about timeouts.
  - `NutPunch_FindLobbies()` will trigger a `NPCB_LobbyList` callback.
  - `NutPunch_RequestLobbyData()` on any visible lobby will trigger a `NPCB_LobbyMetadata` callback.
  - Call `NutPunch_Disconnect()` or just join a lobby when you're done.

- Added back lobby filters. Also makes filters optional in `NutPunch_FindLobbies()` and fixes NutPuncher's matching function.

- Optimized `LIST` and `LGMA` packets to be any length. Both ends can determine filter, lobby and metadata counts by packet size alone.

Lobby query packets are fire-and-forget for both client and NutPuncher, so it is susceptible to the average packet loss problem (does it really matter?). They should also work without `NutPunch_Query()` if you are already in a lobby but I haven't tested that.